### PR TITLE
fixed page 403 forbidden

### DIFF
--- a/js/dev.js
+++ b/js/dev.js
@@ -96,7 +96,9 @@ javascript: void((function (d) {
                     return new Promise(function (resolve, reject) {
                         JSZipUtils.getBinaryContent(url, function (err, data) {
                             if (err) {
-                                reject(err);
+                                var errStr = err.toString();
+                                alert("A Page can't download normally.\n" + errStr);
+                                resolve(errStr);
                             } else {
                                 resolve(data);
                             }


### PR DESCRIPTION
fixed the [issue](https://github.com/hbdoy/hackmd_download/issues/1) , but just edit code in `js/dev.js` .

原本發生403時 頁面會整個卡住不動，更改後會彈出視窗提示(error log)有檔案發生錯誤，並且還是將檔案正常下載，內容為Error log，標題為原本檔案標題。